### PR TITLE
Skeleton for a CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,4 +47,4 @@ line-length = 120
 ignore = "E203"
 
 [project.scripts]
-osccli = "opensubtitlescom.cli:main"
+ost = "ost_cli.main:main"

--- a/src/ost_cli/config.py
+++ b/src/ost_cli/config.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import json
+import logging
+import typing as t
+
+logger = logging.getLogger(__name__)
+
+
+class Config:
+    def __init__(self, path: Path):
+        self._path: Path = path.expanduser()
+        self.username: t.Optional[str] = None
+        self.password: t.Optional[str] = None
+        self.langauge: str = "en"
+
+        if self._path.exists():
+            d = json.loads(self._path.read_text())
+            self.__dict__.update(d)
+
+    def save(self):
+        """Save the configuration to the specified file."""
+        if not self.verify_config_dir():
+            logger.error(f"Failed to save config.")
+            return False
+        data = {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
+        self._path.write_text(json.dumps(data, indent=4))
+        return True
+
+    def verify_config_dir(self):
+        """Verify the existence of the directory specified by self._path.
+
+        If the directory does not exist, attempts to create it.
+
+        Returns:
+            bool: True if the directory exists or is successfully created, False otherwise.
+        """
+        if self._path.exists():
+            return True
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            return True
+        except OSError as e:
+            if e.errno == 30:
+                logger.error(f"Error: {e}. Check if the file system is read-only or permissions are insufficient.")
+            else:
+                logger.error(f"Error: {e}")
+            return False

--- a/src/ost_cli/main.py
+++ b/src/ost_cli/main.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import sys
+import logging
+import argparse
+from typing import List
+
+
+logger = logging.getLogger(__name__)
+
+
+def hello(args: argparse.Namespace):
+    """Just a stub command for the skeleton, this will be replaced in the next commit"""
+    print(f"Hello {args.name}!")
+
+
+def parse_args(argv: List[str]):
+    """Parse command-line arguments for the OpenSubtitles CLI."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase verbosity level")
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    hello_parser = subparsers.add_parser("hello", help=hello.__doc__)
+    hello_parser.set_defaults(command=hello)
+    hello_parser.add_argument("name")
+
+    return parser.parse_args(argv)
+
+
+def main():
+    args = parse_args(sys.argv[1:])
+    logging.basicConfig(
+        level=logging.WARNING - (args.verbose * 10),
+        format="%(asctime)s %(message)s",
+    )
+    if args.command:
+        return args.command(args)
+    else:
+        print("No command given, use --help for usage")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ost_cli/main.py
+++ b/src/ost_cli/main.py
@@ -1,22 +1,83 @@
 #!/usr/bin/env python3
 
+import typing as t
 from pathlib import Path
 import sys
-import logging
 import argparse
-from typing import List
+import os
+import logging
+
+from opensubtitlescom import OpenSubtitles, FileUtils
 from .config import Config
 
-
-logger = logging.getLogger(__name__)
-
-
-def hello(args: argparse.Namespace):
-    """Just a stub command for the skeleton, this will be replaced in the next commit"""
-    print(f"Hello {args.name}!")
+log = logging.getLogger(__name__)
 
 
-def parse_args(argv: List[str]):
+APP_NAME = "CLI Test"
+APP_VER = "0.0.0"
+API_KEY = "F0f1dadQ89xKIP5TIsu3Y8KT7TiDBIfG"
+API_APP = f"{APP_NAME} v{APP_VER}"
+
+def _get_api(cfg: Config):
+    """
+    Create an OpenSubtitles API object and login with the credentials in the config file
+    """
+    subtitles = OpenSubtitles(API_KEY, API_APP)
+    if cfg.username and cfg.password:
+        subtitles.login(cfg.username, cfg.password)
+    return subtitles
+
+
+def login(args: argparse.Namespace):
+    """
+    Check that the login credentials are valid and save them to the config file
+    """
+    try:
+        subtitles = OpenSubtitles(API_KEY, API_APP)
+        subtitles.login(args.username, args.password)
+
+        log.info("Login successful, saving credentials to config file")
+        cfg = Config(args.config)
+        cfg.username = args.username
+        cfg.password = args.password
+        cfg.save()
+    except Exception as e:
+        print(e)
+        return
+
+
+def search(args: argparse.Namespace):
+    """
+    Search for subtitles by various criteria
+    """
+    ...
+
+
+def download(args: argparse.Namespace):
+    """
+    Download a subtitle by file-id or moviehash
+    """
+    cfg = Config(args.config)
+    api = _get_api(cfg)
+
+    if args.key.isdigit():
+        # Given a file-id, download the subtitle
+        ...
+    elif os.path.exists(args.key):
+        # Given a local file, search for the hash and download the first result,
+        # eg "download mymovie.mp4" will download the subtitle for mymovie.mp4
+        # and save it as mymovie.srt
+        mov = Path(args.key)
+        srt = mov.with_suffix(".srt")
+        fu = FileUtils(mov)
+        h = fu.get_hash()
+        response = api.search(moviehash=h, languages=cfg.langauge)
+        log.info("Found %d subtitles, downloading the first into %s", len(response.data), srt)
+        with open(srt, "wb") as fp:
+            fp.write(api.download(file_id=response.data[0].file_id))
+
+
+def parse_args(argv: t.List[str]):
     """Parse command-line arguments for the OpenSubtitles CLI."""
     parser = argparse.ArgumentParser()
     parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase verbosity level")
@@ -24,9 +85,21 @@ def parse_args(argv: List[str]):
 
     subparsers = parser.add_subparsers(dest="command")
 
-    hello_parser = subparsers.add_parser("hello", help=hello.__doc__)
-    hello_parser.set_defaults(command=hello)
-    hello_parser.add_argument("name")
+    login_parser = subparsers.add_parser("login", help=login.__doc__)
+    login_parser.set_defaults(command=login)
+    login_parser.add_argument("username", type=str)
+    login_parser.add_argument("password", type=str)
+
+    search_parser = subparsers.add_parser("search", help=search.__doc__)
+    search_parser.set_defaults(command=search)
+    search_parser.add_argument("--moviehash", type=str)
+    search_parser.add_argument("--languages", type=str)
+
+    download_parser = subparsers.add_parser("download", help=download.__doc__)
+    download_parser.set_defaults(command=download)
+    download_parser.add_argument(
+        "key", type=str, help="unique ID - either file-id, or a local filename to download by moviehash"
+    )
 
     return parser.parse_args(argv)
 

--- a/src/ost_cli/main.py
+++ b/src/ost_cli/main.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
+from pathlib import Path
 import sys
 import logging
 import argparse
 from typing import List
+from .config import Config
 
 
 logger = logging.getLogger(__name__)
@@ -18,6 +20,7 @@ def parse_args(argv: List[str]):
     """Parse command-line arguments for the OpenSubtitles CLI."""
     parser = argparse.ArgumentParser()
     parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase verbosity level")
+    parser.add_argument("--config", type=Path, default="~/.config/opensubtitlescom/cli.json")
 
     subparsers = parser.add_subparsers(dest="command")
 


### PR DESCRIPTION
A minimal proof-of-concept that has the one specific feature that I wanted (downloading subtitles for a given video file), plus skeleton to easily add more commands

(when run on top of the pyproject branch, because I couldn't get the package to install without that)

```
$ pip install -e .
[...]

$ osccli --help
usage: osccli [-h] [--config CONFIG] [-v] {login,search,download} ...

positional arguments:
  {login,search,download}
    login               Check that the login credentials are valid and save them to the config file
    search              Search for subtitles by various criteria
    download            Download a subtitle by file-id or moviehash

options:
  -h, --help            show this help message and exit
  --config CONFIG
  -v, --verbose

$ osccli login MYNAME MYPASS
2023-12-04 12:29:41,935 Login successful, saving credentials to config file

$ osccli download MyVideo.mp4
2023-12-04 12:30:43,844 Found 3 subtitles for MyVideo.mp4, downloading the first one into MyVideo.srt
```