### PR TITLE
remove api key from user config

### DIFF
--- a/src/opensubtitlescom/config.py
+++ b/src/opensubtitlescom/config.py
@@ -34,7 +34,6 @@ class Config:
             If not, the class creates the necessary directory structure for the configuration file.
         """
         self._path: Path = (Path(path or DEFAULT_CONFIG_PATH)).expanduser()
-        self.api_key: Optional[str] = None
         self.username: Optional[str] = None
         self.password: Optional[str] = None
         self.language: str = "en"

--- a/src/opensubtitlescom/opensubtitles.py
+++ b/src/opensubtitlescom/opensubtitles.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 class OpenSubtitles:
     """OpenSubtitles REST API Wrapper."""
 
-    def __init__(self, user_agent: str, api_key: Optional[str] = None):
+    def __init__(self, user_agent: str, api_key: str):
         """Initialize the OpenSubtitles object.
 
         :param api_key:
@@ -52,7 +52,7 @@ class OpenSubtitles:
         self.download_client = DownloadClient()
         self.base_url = "https://api.opensubtitles.com/api/v1"
         self.token = None
-        self.api_key = api_key or self._config.api_key
+        self.api_key = api_key
         self.user_agent = user_agent
         self.downloads_dir = "."
         self.user_downloads_remaining = 0

--- a/src/ost_cli/main.py
+++ b/src/ost_cli/main.py
@@ -65,7 +65,6 @@ def show_credentials(args: argparse.Namespace):
     values = {
         "username": cfg.username,
         "password": hide_secret(cfg.password, 2),
-        "api_key": hide_secret(cfg.api_key, 2),
         "language": cfg.language,
     }
     print(dict_to_pt(values, align="l"))


### PR DESCRIPTION
I asked the opensubtitles.com developers themselves, and they confirmed that API key should be hard-coded into the application (in our case, the CLI), not configured by the end-user

In particular, API key and User Agent need to come as a pair - if you submit one without the other, or submit a pair which don't match (eg if you get User Agent from the application and API key from the user config) then the server will reject you

(In this case the name "API key" is slightly misleading as it isn't a secret, it's more like "User Agent part 2" - it is used purely to identify which software is being used, in contrast to username / password which are used to identify the user)