### PR TITLE
Add _get_api helper

### DIFF
--- a/src/ost_cli/main.py
+++ b/src/ost_cli/main.py
@@ -16,11 +16,26 @@ import argparse
 from typing import List
 from pathlib import Path
 
-from opensubtitlescom import Config
+from opensubtitlescom import Config, OpenSubtitles
 
 from .table import dict_to_pt
 
 logger = logging.getLogger(__name__)
+
+APP_NAME = "CLI Test"
+APP_VER = "0.0.0"
+API_KEY = "F0f1dadQ89xKIP5TIsu3Y8KT7TiDBIfG"
+API_APP = f"{APP_NAME} v{APP_VER}"
+
+
+def _get_api(cfg: Config):
+    """
+    Create an OpenSubtitles API object and login with the credentials in the config file
+    """
+    subtitles = OpenSubtitles(API_APP, API_KEY)
+    if cfg.username and cfg.password:
+        subtitles.login(cfg.username, cfg.password)
+    return subtitles
 
 
 def hello(args: argparse.Namespace):


### PR DESCRIPTION
As suggested by the opensubtitles.com developers - hardcoding the User Agent and API key into the application.

Although since I'm not the project maintainer, it seems silly for the app to be using a User Agent + Key that I've registered - I would recommend that the maintainer register their own app, and then replace the `APP_NAME` / `API_KEY` variables with ones that they control :)

(This function isn't used yet, I just want to get agreement on how to do it before writing more code on top of it)